### PR TITLE
CMakeLists.txt: honour CMAKE_INSTALL_PREFIX and leave source pristine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,17 +18,21 @@ ELSEIF( CMAKE_SYSTEM_NAME STREQUAL "SunOS" )
     SET(IS_SUNOS 1)
 ENDIF()
 
-CONFIGURE_FILE(headers/conf.h.in ${CMAKE_SOURCE_DIR}/headers/conf.h)
+CONFIGURE_FILE(headers/conf.h.in ${CMAKE_BINARY_DIR}/headers/conf.h)
 
 # Compiler configuration
-INCLUDE_DIRECTORIES(BEFORE ${CMAKE_SOURCE_DIR}/headers/)
+INCLUDE_DIRECTORIES(BEFORE ${CMAKE_BINARY_DIR}/headers/ ${CMAKE_SOURCE_DIR}/headers/)
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ADD_DEFINITIONS(-Wall -Wextra)
 #ADD_DEFINITIONS(-DVERBOSE)
 
+IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    SET(CMAKE_INSTALL_PREFIX "/usr")
+ENDIF()
+
 # Install directories
-SET(HEADER_DIR /usr/include/libsocket)
-SET(LIB_DIR /usr/lib)
+SET(HEADER_DIR "include/libsocket")
+SET(LIB_DIR "lib")
 
 ADD_SUBDIRECTORY(C/)
 ADD_SUBDIRECTORY(headers/)


### PR DESCRIPTION
LIB_DIR was hardcoding the installation directory to /usr/lib which made CMAKE_INSTALL_PREFIX be totally ignored. I've assumed that the original author specifically wanted /usr the default prefix rather than /usr/local - if this is not the case it'd probably be better to let it default to /usr/local and "do the expected thing" for end users (if so, please let this change happen before merging).

Also, conf.h is output to CMAKE_BINARY_DIR so that when the project is built out-of-tree (e.g. mkdir ../libsocket-build; cd ../libsocket-build; cmake ../libsocket/ ) the source tree remains untouched.

These changes have only been tested in Linux.