### PR TITLE
Use correct value for timeout.

### DIFF
--- a/headers/select.hpp
+++ b/headers/select.hpp
@@ -178,7 +178,7 @@ namespace libsocket
 	    timeout = &_timeout;
 
 	    long long micropart = microsecs % 1000000;
-	    long long secpart   = (microsecs - micropart) / 1000000;
+	    long long secpart   = microsecs / 1000000;
 
 	    _timeout.tv_sec  = secpart;
 	    _timeout.tv_usec = micropart;

--- a/headers/select.hpp
+++ b/headers/select.hpp
@@ -181,7 +181,7 @@ namespace libsocket
 	    long long secpart   = (microsecs - micropart) / 1000000;
 
 	    _timeout.tv_sec  = secpart;
-	    _timeout.tv_usec = microsecs;
+	    _timeout.tv_usec = micropart;
 	}
 
 	n = select(highestfd(filedescriptors)+1,&readset,&writeset,NULL,timeout);


### PR DESCRIPTION
Was causing timeouts greater than one second to last twice as long. More or less.