### PR TITLE
allow const std::string to be sent to unix stream and dgram clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ srv
 *.swp
 *.a
 *.kdev4
+headers/conf.h

--- a/C++/dgramclient.cpp
+++ b/C++/dgramclient.cpp
@@ -167,7 +167,7 @@ namespace libsocket
      *
      * Usage: `socket << "Abcde";`
      */
-    dgram_client_socket& operator<<(dgram_client_socket& sock, string& str)
+    dgram_client_socket& operator<<(dgram_client_socket& sock, const string& str)
     {
 	if ( sock.connected == false )
 	    throw socket_exception(__FILE__,__LINE__,"dgram_client_socket <<(std::string) output: DGRAM socket not connected!");

--- a/C++/streamclient.cpp
+++ b/C++/streamclient.cpp
@@ -184,7 +184,7 @@ namespace libsocket
      * @param str Data.
      *
      */
-    stream_client_socket& operator<<(stream_client_socket& sock, string& str)
+    stream_client_socket& operator<<(stream_client_socket& sock, const string& str)
     {
 	if ( sock.shut_wr == true )
 	    throw socket_exception(__FILE__,__LINE__,"stream_client_socket::operator<<(std::string) - Socket has already been shut down!",false);

--- a/headers/dgramclient.hpp
+++ b/headers/dgramclient.hpp
@@ -57,7 +57,7 @@ namespace libsocket
 	    dgram_client_socket(void);
 
 	    friend dgram_client_socket& operator<<(dgram_client_socket& sock, const char* str);
-	    friend dgram_client_socket& operator<<(dgram_client_socket& sock, string& str);
+	    friend dgram_client_socket& operator<<(dgram_client_socket& sock, const string& str);
 
 	    ssize_t snd(const void* buf, size_t len, int flags=0); // flags: send()
 

--- a/headers/streamclient.hpp
+++ b/headers/streamclient.hpp
@@ -57,7 +57,7 @@ namespace libsocket
 	    ssize_t rcv(void* buf, size_t len, int flags=0); // flags: recv()
 
 	    friend stream_client_socket& operator<<(stream_client_socket& sock, const char* str);
-	    friend stream_client_socket& operator<<(stream_client_socket& sock, string& str);
+	    friend stream_client_socket& operator<<(stream_client_socket& sock, const string& str);
 	    friend stream_client_socket& operator>>(stream_client_socket& sock, string& dest);
 
 	    void shutdown(int method=LIBSOCKET_WRITE);


### PR DESCRIPTION
previously doing something akin to this:

const std::string s = "ok";
*client << s;

would result in a compile error. 

the string ref can be const in these functions as they do not mutate it.