### PR TITLE
make libsocket a catkin package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>libsocket</name>
+  <version>0.0.0</version>
+  <description>The libsocket package</description>
+
+  <maintainer email="lbo@spheniscida.de">dermesser</maintainer>
+
+  <license>2-clause BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+
+</package>


### PR DESCRIPTION
add package.xml so catkin (http://wiki.ros.org/catkin) can find this package. Use the following to link to the library:
target_link_libraries(my_lib ${CATKIN_DEVEL_PREFIX}/lib/libsocket++.so)

Its not perfect, it needs the following improvements:
- The CPackConfig.cmake files end up in the build directory (should be in the devel).  I think this may be an issue with CPack not working well with catkin.
- The target_link_libraries reference to libsocket++.so should look more like:
target_link_libraries(my_lib ${libsocket_LIBRARIES})
