### PR TITLE
Release allocated memory by getaddrinfo - memory leak fix

### DIFF
--- a/C/inet/libinetsocket.c
+++ b/C/inet/libinetsocket.c
@@ -339,6 +339,8 @@ ssize_t sendto_inet_dgram_socket(int sfd, const void* buf, size_t size, const ch
 	}
     }
 
+    freeaddrinfo(result);
+
     return return_value;
 }
 


### PR DESCRIPTION
In file libinetsocket.c on line 322, `getaddrinfo` allocates memory that is not released anywhere later and that causes memory leak on every call of `sendto_inet_dgram_socket`. 

Adding `freeaddrinfo` on line 342 should fix this.

Thank you for this lib, it's great :1st_place_medal: 