### PR TITLE
Add cmake option for building static libraries.

### DIFF
--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -26,8 +26,23 @@ unixclientstream.cpp
 unixserverdgram.cpp
 )
 
-ADD_LIBRARY(socket++ SHARED ${sources})
+ADD_DEFINITIONS(-fPIC) # for the static library which needs to be linked into the shared libsocket++.so object.
+ADD_LIBRARY(socket++_o OBJECT ${sources})
+
+IF(BUILD_SHARED_LIBS)
+ADD_LIBRARY(socket++ SHARED $<TARGET_OBJECTS:socket++_o>)
 
 TARGET_LINK_LIBRARIES(socket++ socket_int)
 
 INSTALL(TARGETS socket++ DESTINATION ${LIB_DIR})
+ENDIF()
+
+IF(BUILD_STATIC_LIBS)
+ADD_LIBRARY(socket++_int STATIC $<TARGET_OBJECTS:socket++_o>)
+
+SET_TARGET_PROPERTIES(socket++_int PROPERTIES OUTPUT_NAME socket++)
+
+TARGET_LINK_LIBRARIES(socket++_int socket_int)
+
+INSTALL(TARGETS socket++_int DESTINATION ${LIB_DIR})
+ENDIF()

--- a/C/CMakeLists.txt
+++ b/C/CMakeLists.txt
@@ -9,10 +9,19 @@ IF ( NOT IS_SUNOS )
     ADD_DEFINITIONS(-fPIC) # for the static library which needs to be linked into the shared libsocket++.so object.
     ADD_LIBRARY(socket_o OBJECT ${libsocket_src})
 
+    ADD_LIBRARY(socket_int STATIC $<TARGET_OBJECTS:socket_o>) #Static lib must be built for linking libsocket++
+
+    IF(BUILD_SHARED_LIBS)
     ADD_LIBRARY(socket SHARED $<TARGET_OBJECTS:socket_o>)
-    ADD_LIBRARY(socket_int STATIC $<TARGET_OBJECTS:socket_o>)
 
     INSTALL(TARGETS socket DESTINATION ${LIB_DIR})
+    ENDIF()
+
+
+    IF(BUILD_STATIC_LIBS)
+        SET_TARGET_PROPERTIES(socket_int PROPERTIES OUTPUT_NAME socket)
+        INSTALL(TARGETS socket_int DESTINATION ${LIB_DIR})
+    ENDIF()
 ELSE() # On SunOS (e.g. OpenIndiana) we have to link against the system's libsocket. The library is renamed to libsocket_hl (hl = high-level)
     ADD_LIBRARY(socket_hl SHARED ${libsocket_src})
     FIND_LIBRARY(solaris_socket_lib socket)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ ELSEIF( CMAKE_SYSTEM_NAME STREQUAL "SunOS" )
     SET(IS_SUNOS 1)
 ENDIF()
 
+OPTION(BUILD_STATIC_LIBS "Build the static library" OFF)
+OPTION(BUILD_SHARED_LIBS "Build the shared library" ON)
+
 CONFIGURE_FILE(headers/conf.h.in ${CMAKE_CURRENT_BINARY_DIR}/headers/conf.h)
 
 # Compiler configuration

--- a/README.md
+++ b/README.md
@@ -127,6 +127,23 @@ text in your product (so it's clear that libsocket is licensed by this License) 
 *we* wrote libsocket (as described in the license). It's ok to mention libsocket in your product's
 Readme or advertisements anyway.
 
+#### Static Linkage in CMake Projects
+
+It is possible to produce static libraries for linking by setting the cmake
+configuration option, `BUILD_STATIC_LIBS=ON`. This can be done from command
+line or in your CMakeLists.txt.
+
+```cmake
+SET(BUILD_SHARED_LIBS ON)
+add_subdirectory(libsocket)
+
+target_link_libraries(MyProject libsocket_int) # C linking
+target_link_libraries(MyProject libsocket++_int) # C++ linking
+```
+
+Please note the cmake targets for static libraries are \<libname>\_int, but
+the produced libraries will have the libsocket(++).a name on disk.
+
 ### Dynamic Linkage
 
 The recommended method to use libsocket is to link your program against the libsocket SO (DLL). Using this


### PR DESCRIPTION
This add a cmake option for building the static libraries to make static linking easier from cmake projects. An update to the readme is added showing the new option.

There is no changes to existing builds unless the BUILD_STATIC_LIBS option is set.