### PR TITLE
Remove "using std::string" from the global namespace.

### DIFF
--- a/headers/dgramclient.hpp
+++ b/headers/dgramclient.hpp
@@ -6,8 +6,6 @@
 # include <unistd.h>
 # include <string.h>
 
-using std::string;
-
 /**
  * @file dgramclient.hpp
  *
@@ -38,6 +36,8 @@ using std::string;
 
 namespace libsocket
 {
+    using std::string;
+
     /**
      * @addtogroup libsocketplusplus
      * @{

--- a/headers/exception.hpp
+++ b/headers/exception.hpp
@@ -32,9 +32,9 @@
 
  */
 
-using std::string;
 namespace libsocket
 {
+    using std::string;
     /**
      * @addtogroup libsocketplusplus
      * @{

--- a/headers/streamclient.hpp
+++ b/headers/streamclient.hpp
@@ -30,10 +30,10 @@
    POSSIBILITY OF SUCH DAMAGE.
 
 */
-using std::string;
 
 namespace libsocket
 {
+    using std::string;
     class dgram_over_stream;
 
     /** @addtogroup libsocketplusplus

--- a/headers/unixclientdgram.hpp
+++ b/headers/unixclientdgram.hpp
@@ -33,10 +33,10 @@
 
 */
 
-using std::string;
-
 namespace libsocket
 {
+    using std::string;
+
     /** @addtogroup libsocketplusplus
      * @{
      */

--- a/headers/unixserverdgram.hpp
+++ b/headers/unixserverdgram.hpp
@@ -32,10 +32,10 @@
 
 */
 
-using std::string;
-
 namespace libsocket
 {
+    using std::string;
+
     /** @addtogroup libsocketplusplus
      * @{
      */


### PR DESCRIPTION
This can fail to compile in projects where there's a separate string defined in the global namespace rather than std::string (rare, but it happens). It was already defined in the libsocket namespace in other headers, so we unified it to do that everywhere rather than have some headers define it under the namespace and some define it globally.