### PR TITLE
Fix linking issue in examples/examples++

### DIFF
--- a/examples++/test.sh
+++ b/examples++/test.sh
@@ -17,8 +17,8 @@ echo "Starting test suite examples++/..."
 ### TCP client/server
 echo "Testing TCP client/server..."
 
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o srv -lsocket++ server.cpp
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl  -lsocket++ client.cpp
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o srv server.cpp -lsocket++
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl  client.cpp -lsocket++
 
 ./srv > /dev/null &
 sleep 1
@@ -31,9 +31,9 @@ rm srv cl
 ### echo client/server
 echo "Testing echo client/server..."
 
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl_conn -lsocket++ echo_client_conn.cpp
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl_sndto -lsocket++ echo_client_sndto.cpp
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o srv -lsocket++ echo_server.cpp
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl_conn echo_client_conn.cpp -lsocket++
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl_sndto echo_client_sndto.cpp -lsocket++
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o srv echo_server.cpp -lsocket++
 
 ./srv > /dev/null &
 sleep 1
@@ -47,8 +47,8 @@ rm srv cl_sndto cl_conn
 ### HTTP clients
 echo "Testing HTTP clients..."
 
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o http1 -lsocket++ http.cpp
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o http2 -lsocket++ http_2.cpp
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o http1 http.cpp -lsocket++
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o http2 http_2.cpp -lsocket++
 
 ./http1 > /dev/null
 ./http2 > /dev/null
@@ -58,7 +58,7 @@ rm http1 http2
 ### UNIX dgram client (log client)
 echo "Testing UNIX dgram client (log client)..."
 
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl -lsocket++ unix_dgram_syslogclient.cpp
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl unix_dgram_syslogclient.cpp -lsocket++
 
 ./cl > /dev/null
 
@@ -67,8 +67,8 @@ rm cl
 ### UNIX dgram client/server
 echo "Testing UNIX dgram client/server..."
 
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o srv -lsocket++ unix_dgram_server.cpp
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl -lsocket++ unix_dgram_client.cpp
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o srv unix_dgram_server.cpp -lsocket++
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl unix_dgram_client.cpp -lsocket++
 
 ./srv > /dev/null &
 sleep 1
@@ -81,8 +81,8 @@ rm cl srv
 ### UNIX stream server/client
 echo "Testing UNIX STREAM client/server..."
 
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o srv -lsocket++ unix_server_stream.cpp
-g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl -lsocket++ unix_client_stream.cpp
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o srv unix_server_stream.cpp -lsocket++
+g++ $CPPFLAGS -I$HEADERPATH -L$LIBPATH -o cl unix_client_stream.cpp -lsocket++
 
 ./srv > /dev/null &
 sleep 1

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -15,8 +15,8 @@ echo "Starting test suite examples/..."
 
 echo "Testing TCP client/server (transmission*.c)..."
 
-gcc -I$HEADERPATH -L$LIBPATH -o cl -lsocket transmission_client.c
-gcc -I$HEADERPATH -L$LIBPATH -o srv -lsocket transmission_server.c
+gcc -I$HEADERPATH -L$LIBPATH -o cl transmission_client.c -lsocket
+gcc -I$HEADERPATH -L$LIBPATH -o srv transmission_server.c -lsocket
 
 ./srv > /dev/null &
 sleep 1
@@ -28,9 +28,9 @@ rm srv cl
 
 echo "Testing echo UDP programs..."
 
-gcc -I$HEADERPATH -L$LIBPATH -o cl -lsocket echo_dgram_client.c
-gcc -I$HEADERPATH -L$LIBPATH -o clc -lsocket echo_dgram_connect_client.c
-gcc -I$HEADERPATH -L$LIBPATH -o srv -lsocket echo_dgram_server.c
+gcc -I$HEADERPATH -L$LIBPATH -o cl echo_dgram_client.c -lsocket
+gcc -I$HEADERPATH -L$LIBPATH -o clc echo_dgram_connect_client.c -lsocket
+gcc -I$HEADERPATH -L$LIBPATH -o srv echo_dgram_server.c -lsocket
 
 ./srv > /dev/null &
 sleep 1
@@ -43,7 +43,7 @@ rm srv clc cl
 
 echo "Testing HTTP client..."
 
-gcc -o http -lsocket http.c
+gcc -o http http.c -lsocket
 
 ./http > /dev/null
 
@@ -51,9 +51,9 @@ rm http
 
 echo "Testing UNIX dgram client/server..."
 
-gcc -I$HEADERPATH -L$LIBPATH -o cl -lsocket unix_dgram_client.c
-gcc -I$HEADERPATH -L$LIBPATH -o clc -lsocket unix_dgram_connected_client.c
-gcc -I$HEADERPATH -L$LIBPATH -o srv  -lsocket unix_dgram_server.c
+gcc -I$HEADERPATH -L$LIBPATH -o cl unix_dgram_client.c -lsocket
+gcc -I$HEADERPATH -L$LIBPATH -o clc unix_dgram_connected_client.c -lsocket
+gcc -I$HEADERPATH -L$LIBPATH -o srv  unix_dgram_server.c -lsocket
 
 ./srv > /dev/null &
 sleep 1
@@ -66,8 +66,8 @@ rm srv clc cl
 
 echo "Testing UNIX stream client/server..."
 
-gcc -I$HEADERPATH -L$LIBPATH -o srv -lsocket unix_stream_server.c
-gcc -I$HEADERPATH -L$LIBPATH -o cl -lsocket unix_stream_client.c
+gcc -I$HEADERPATH -L$LIBPATH -o srv unix_stream_server.c -lsocket
+gcc -I$HEADERPATH -L$LIBPATH -o cl unix_stream_client.c -lsocket
 
 ./srv > /dev/null &
 sleep 1


### PR DESCRIPTION
When examples/test.sh tried to compile sample program, it failed by link error.

=== MAKE SURE YOU INSTALLED THE LATEST VERSION AS S/O! ===
Starting test suite examples/...
Testing TCP client/server (transmission*.c)...
/tmp/ccIko3cF.o: In function `main':
transmission_client.c:(.text+0x25): undefined reference to `create_inet_stream_socket'
transmission_client.c:(.text+0x85): undefined reference to `destroy_inet_socket'
collect2: error: ld returned 1 exit status

The linker searches object files and libraries in the order they specified.
Thus functions in previous object may not be loaded.