### PR TITLE
Fix capital letters in cmake find module package name

### DIFF
--- a/libsocketConfig.cmake.in
+++ b/libsocketConfig.cmake.in
@@ -1,7 +1,7 @@
-set(LIBSOCKET_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+set(libsocket_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 
-set(LIBSOCKET_BINARY_DIR "@PROJECT_BINARY_DIR@")
+set(libsocket_BINARY_DIR "@PROJECT_BINARY_DIR@")
 
-include(${LIBSOCKET_BINARY_DIR}/libsocketTargets.cmake)
+include(${libsocket_BINARY_DIR}/libsocketTargets.cmake)
 
-set(LIBSOCKET_LIBRARIES socket++)
+set(libsocket_LIBRARIES socket++)


### PR DESCRIPTION
This is a follow up to #45 

The standard `_INCLUDE_DIRS` and `_BINARY_DIR` etc.. should respect package name capitalization;
https://gitlab.kitware.com/cmake/community/wikis/doc/tutorials/How-To-Find-Libraries

This is not a functional change, this help removes warning when `catkin` (from Robot Operating System) expects the right capitalization:
```cmake
CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'libsocket' but neither
  'libsocket_INCLUDE_DIRS' nor 'libsocket_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  keyence_experimental/CMakeLists.txt:22 (catkin_package)
```

@AustinDeric , @Jmeyer1292 this is useful for my rework of the Keyence experimental package (I have not yet made a pull request)