### PR TITLE
Fix server.destroy() call before destructor

### DIFF
--- a/examples++/echo_server.cpp
+++ b/examples++/echo_server.cpp
@@ -32,7 +32,7 @@ int main(void)
 	    srv.sndto(answer,from,fromport);
 	}
 
-	srv.destroy();
+	//srv.destroy(); //libsocket::inet_dgram_server has destructor
     } catch (const libsocket::socket_exception& exc)
     {
 	std::cerr << exc.mesg;

--- a/examples++/echo_server.cpp
+++ b/examples++/echo_server.cpp
@@ -31,7 +31,7 @@ int main(void)
 
 	    srv.sndto(answer,from,fromport);
 	}
-	//libsocket::inet_dgram_server also has a destructor doing this for us, so we are doing explicitly and can reuse the socket. This line is part of build test suite.
+	//libsocket::inet_dgram_server also has a destructor doing this for us, so we are doing explicitly and can reuse the socket.
 	srv.destroy();
     } catch (const libsocket::socket_exception& exc)
     {

--- a/examples++/echo_server.cpp
+++ b/examples++/echo_server.cpp
@@ -31,8 +31,8 @@ int main(void)
 
 	    srv.sndto(answer,from,fromport);
 	}
-
-	//srv.destroy(); //libsocket::inet_dgram_server has destructor
+	//libsocket::inet_dgram_server also has a destructor doing this for us, so we are doing explicitly and can reuse the socket. This line is part of build test suite.
+	srv.destroy();
     } catch (const libsocket::socket_exception& exc)
     {
 	std::cerr << exc.mesg;


### PR DESCRIPTION
Isn't the libsocket::inet_dgram_server function destroy() part of destructor? As from client example, and HTTP example, this causes inconsistency for a first reader.