### PR TITLE
Inherit CMAKE_CXX_FLAGS in C++ CMakeLists

### DIFF
--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-SET(CMAKE_CXX_FLAGS "-std=c++11") # -DVERBOSE")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11") # -DVERBOSE")
 
 ADD_DEFINITIONS("-DMIXED")
 


### PR DESCRIPTION
C++/CMakeLists.txt overrides CMAKE_CXX_FLAGS which breaks 32-bit builds.