### PR TITLE
Allow non-blocking client sockets to be created

### DIFF
--- a/C/inet/libinetsocket.c
+++ b/C/inet/libinetsocket.c
@@ -201,10 +201,11 @@ int create_inet_stream_socket(const char *host, const char *service,
         if (sfd < 0)  // Error!!!
             continue;
 
-        if (-1 != connect(sfd, result_check->ai_addr,
-                          result_check->ai_addrlen))  // connected without error
-            break;
-
+        int CON_RES = connect(sfd, result_check->ai_addr,
+                              result_check->ai_addrlen);
+        if ((CON_RES != -1) || (CON_RES == -1 && (flags |= SOCK_NONBLOCK) && ((errno == EINPROGRESS) || (errno == EALREADY) || (errno == EINTR))))     // connected without error, or, connected with errno being one of these important states
+             break;
+       
         close(sfd);
     }
 


### PR DESCRIPTION
When SOCK_NONBLOCK is set on a socket, it will always return with one of these three errnos:  EINPROGRESS, EALREADY, EINTR, so libsocket would reject the connection as failed. With this change, it will allow through those connections if the proper flag is set and it gets one of the three accepted errors. An important note though, this will return successfully even if the target socket -doesn't exist at all-, a true failure. The way to properly check if a nonblocking socket is connected, is to see if we can read/write to it. If we can, great! If not, we probably didn't connect correctly.