### PR TITLE
Fix memory leak in get_address_family

### DIFF
--- a/C/inet/libinetsocket.c
+++ b/C/inet/libinetsocket.c
@@ -939,6 +939,8 @@ int get_address_family(const char *hostname) {
         af = -1;
     }
 
+    freeaddrinfo(result);
+
     return af;
 }
 


### PR DESCRIPTION
The handle `result` is created at libinetsocket.c:924 by calling function `getaddrinfo` and lost

https://github.com/dermesser/libsocket/blob/fe5f78c997478a1915f44a494a50025bdc792698/C/inet/libinetsocket.c#L924-L943

Found with Svace