### PR TITLE
Fix possible double close and closing uninitialized fd in create_inet_stream_socket

### DIFF
--- a/C/inet/libinetsocket.c
+++ b/C/inet/libinetsocket.c
@@ -152,7 +152,7 @@ static inline signed int check_error(int return_value) {
  */
 int create_inet_stream_socket(const char *host, const char *service,
                               char proto_osi3, int flags) {
-    int sfd, return_value;
+    int sfd = -1, return_value;
     struct addrinfo hint, *result, *result_check;
 #ifdef VERBOSE
     const char *errstring;
@@ -207,6 +207,7 @@ int create_inet_stream_socket(const char *host, const char *service,
              break;
        
         close(sfd);
+        sfd = -1;
     }
 
     // We do now have a working socket STREAM connection to our target


### PR DESCRIPTION
1. Possible uninitialized data is read from local variable `sfd` at libinetsocket.c:221.
https://github.com/dermesser/libsocket/blob/1a4480a1214cb68cbf28c7f7050cdd76ab85d6f0/C/inet/libinetsocket.c#L155
https://github.com/dermesser/libsocket/blob/1a4480a1214cb68cbf28c7f7050cdd76ab85d6f0/C/inet/libinetsocket.c#L221

2. Handler `sfd` is passed to a function at libinetsocket.c:221 by calling function `close` after the handler may already be closed at libinetsocket.c:209.
https://github.com/dermesser/libsocket/blob/1a4480a1214cb68cbf28c7f7050cdd76ab85d6f0/C/inet/libinetsocket.c#L194-L221

Setting fd to -1 would avoid the risk of closing a socket that another thread had just opened

Found with Svace